### PR TITLE
add node env tests in addition to DOM

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+/** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
 
 export default {
   preset: "ts-jest",

--- a/src/index.jsdom.unit.spec.ts
+++ b/src/index.jsdom.unit.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * ENV set to "jsdom" to assert functionality executing in the browser
+ * @jest-environment jsdom
+ */
+
+import AuthorizationService from "./index";
+
+describe("Authorization Service", () => {
+  it("initializes with empty policy map", () => {
+    expect(AuthorizationService.getPolicyMap()).toEqual([]);
+  });
+
+  it("retrieves profile information asychronously with profileAuthorize() invocation", async () => {
+    // mocking fetch for this test, but if it becomes relevant to other tests in this suite, it
+    // should be elevated to the whole suite (describe)
+
+    // ignoring this type error for now since it is for a mock in test
+    // need to revisit this
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ roles: ["contact_center_associate"] }),
+      }),
+    );
+
+    const aToken = "a_sample_token";
+    const aTokenHeader = "token-header";
+    const aProfileURL = "sample/profile/url";
+    const profile = await AuthorizationService.profileAuthorize(
+      aProfileURL,
+      aTokenHeader,
+      aToken,
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(aProfileURL, {
+      headers: new Headers({
+        cookie: `token-header=a_sample_token`,
+      }),
+    });
+    expect(profile).toEqual({ roles: ["contact_center_associate"] });
+  });
+
+  it("adds a policy when defineUser() called with new role(s)", () => {
+    AuthorizationService.defineRole("contact_center_associate", [
+      "manualPayments",
+      "existingOrderCancellation",
+      "common_auth",
+    ]);
+
+    expect(AuthorizationService.getPolicyMap()).toEqual([
+      {
+        role: "contact_center_associate",
+        policies: [
+          "manualPayments",
+          "existingOrderCancellation",
+          "common_auth",
+        ],
+      },
+    ]);
+
+    AuthorizationService.defineRole("store_associate", [
+      "ingredientLocking",
+      "common_auth",
+    ]);
+
+    expect(AuthorizationService.getPolicyMap()).toEqual([
+      {
+        role: "contact_center_associate",
+        policies: [
+          "manualPayments",
+          "existingOrderCancellation",
+          "common_auth",
+        ],
+      },
+      {
+        role: "store_associate",
+        policies: ["ingredientLocking", "common_auth"],
+      },
+    ]);
+  });
+
+  it("does not add a new policy if the role has already been defined", () => {
+    expect(
+      AuthorizationService.defineRole("store_associate", ["ingredientLocking"]),
+    ).toBe(false);
+
+    expect(AuthorizationService.getPolicyMap()).toEqual([
+      {
+        role: "contact_center_associate",
+        policies: [
+          "manualPayments",
+          "existingOrderCancellation",
+          "common_auth",
+        ],
+      },
+      {
+        role: "store_associate",
+        policies: ["ingredientLocking", "common_auth"],
+      },
+    ]);
+  });
+
+  it("returns access confirmation or denial based on provided role information", () => {
+    expect(
+      AuthorizationService.userCan(
+        ["contact_center_associate"],
+        "manualPayments",
+      ),
+    ).toBe(true);
+    expect(
+      AuthorizationService.userCan(["store_associate"], "ingredientLocking"),
+    ).toBe(true);
+    expect(
+      AuthorizationService.userCan(
+        ["contact_center_associate"],
+        "ingredientLocking",
+      ),
+    ).toBe(false);
+    expect(
+      AuthorizationService.userCan(["store_associate"], "manualPayments"),
+    ).toBe(false);
+    expect(
+      AuthorizationService.userCan(["store_associate"], "common_auth"),
+    ).toBe(true);
+    expect(
+      AuthorizationService.userCan(
+        ["store_associate", "contact_center_associate"],
+        "unregistered_policy",
+      ),
+    ).toBe(false);
+    expect(
+      AuthorizationService.userCan(
+        ["store_associate", "contact_center_associate"],
+        "common_auth",
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/index.node.unit.spec.ts
+++ b/src/index.node.unit.spec.ts
@@ -1,11 +1,13 @@
 /**
- * ENV set to "jsdom" in order to gain the fetch API (Headers in particular)
- * @jest-environment jsdom
+ * ENV set to "node" to assert functionality executing on the server.
+ * This setting is redundant to the default jest config in `jest.config.js`,
+ * but is helpful to have here for clarity.
+ * @jest-environment node
  */
 
 import AuthorizationService from "./index";
 
-describe("Authorization Service", () => {
+describe("Authorization Service :: Node", () => {
   it("initializes with empty policy map", () => {
     expect(AuthorizationService.getPolicyMap()).toEqual([]);
   });
@@ -20,7 +22,7 @@ describe("Authorization Service", () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () => Promise.resolve({ roles: ["contact_center_associate"] }),
-      })
+      }),
     );
 
     const aToken = "a_sample_token";
@@ -29,7 +31,7 @@ describe("Authorization Service", () => {
     const profile = await AuthorizationService.profileAuthorize(
       aProfileURL,
       aTokenHeader,
-      aToken
+      aToken,
     );
 
     expect(global.fetch).toHaveBeenCalledWith(aProfileURL, {
@@ -81,7 +83,7 @@ describe("Authorization Service", () => {
 
   it("does not add a new policy if the role has already been defined", () => {
     expect(
-      AuthorizationService.defineRole("store_associate", ["ingredientLocking"])
+      AuthorizationService.defineRole("store_associate", ["ingredientLocking"]),
     ).toBe(false);
 
     expect(AuthorizationService.getPolicyMap()).toEqual([
@@ -104,35 +106,35 @@ describe("Authorization Service", () => {
     expect(
       AuthorizationService.userCan(
         ["contact_center_associate"],
-        "manualPayments"
-      )
+        "manualPayments",
+      ),
     ).toBe(true);
     expect(
-      AuthorizationService.userCan(["store_associate"], "ingredientLocking")
+      AuthorizationService.userCan(["store_associate"], "ingredientLocking"),
     ).toBe(true);
     expect(
       AuthorizationService.userCan(
         ["contact_center_associate"],
-        "ingredientLocking"
-      )
+        "ingredientLocking",
+      ),
     ).toBe(false);
     expect(
-      AuthorizationService.userCan(["store_associate"], "manualPayments")
+      AuthorizationService.userCan(["store_associate"], "manualPayments"),
     ).toBe(false);
     expect(
-      AuthorizationService.userCan(["store_associate"], "common_auth")
+      AuthorizationService.userCan(["store_associate"], "common_auth"),
     ).toBe(true);
     expect(
       AuthorizationService.userCan(
         ["store_associate", "contact_center_associate"],
-        "unregistered_policy"
-      )
+        "unregistered_policy",
+      ),
     ).toBe(false);
     expect(
       AuthorizationService.userCan(
         ["store_associate", "contact_center_associate"],
-        "common_auth"
-      )
+        "common_auth",
+      ),
     ).toBe(true);
   });
 });


### PR DESCRIPTION
Adds execution in Node environment in addition to jsdom to assert functionality both in the browser and server.

https://github.com/PublicisSapient/authorization-util/issues/282